### PR TITLE
When calling stop, state is loss, leading to missed steps on next step / step_for call. 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@ pub trait StepperMotor {
     fn step_for(&mut self, steps: i32, delay: u32) -> Result<(), StepError>;
     /// Set the stepping direction
     fn set_direction(&mut self, dir: Direction);
-    /// Stoping sets all pins low and resets the inner state. First few calls to step might not work as expected
+    /// Stoping sets all pins low and resets the inner state. Might skip some steps next time step / step_for is called
     fn stop(&mut self) -> Result<(), StepError>;
     /// Same as stop, but preserve the steps state, so calling step after this should continue as expected
     fn power_off(&mut self) -> Result<(), StepError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,9 +180,9 @@ pub trait StepperMotor {
     fn step_for(&mut self, steps: i32, delay: u32) -> Result<(), StepError>;
     /// Set the stepping direction
     fn set_direction(&mut self, dir: Direction);
-    /// Stoping sets all pins low, resets the steps state
+    /// Stoping sets all pins low and resets the inner state. First few calls to step might not work as expected
     fn stop(&mut self) -> Result<(), StepError>;
-    /// Power off the motor, preserve the steps state
+    /// Same as stop, but preserve the steps state, so calling step after this should continue as expected
     fn power_off(&mut self) -> Result<(), StepError>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,6 @@ pub trait StepperMotor {
     fn set_direction(&mut self, dir: Direction);
     /// Stoping sets all pins low
     fn stop(&mut self) -> Result<(), StepError>;
-
 }
 
 /// Direction the motor turns in. Just reverses the order of the internal states.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,14 @@ impl<P1: OutputPin, P2: OutputPin, P3: OutputPin, P4: OutputPin, D: DelayNs>
         self.apply_state()?;
         Ok(())
     }
+
+    fn power_off(&mut self) -> Result<(), StepError> {
+        set_state(&mut self.in1, Low)?;
+        set_state(&mut self.in2, Low)?;
+        set_state(&mut self.in3, Low)?;
+        set_state(&mut self.in4, Low)?;
+        Ok(())
+    }
 }
 
 fn set_state<P: OutputPin>(pin: &mut P, state: PinState) -> Result<(), StepError> {
@@ -172,8 +180,10 @@ pub trait StepperMotor {
     fn step_for(&mut self, steps: i32, delay: u32) -> Result<(), StepError>;
     /// Set the stepping direction
     fn set_direction(&mut self, dir: Direction);
-    /// Stoping sets all pins low
+    /// Stoping sets all pins low, resets the steps state
     fn stop(&mut self) -> Result<(), StepError>;
+    /// Power off the motor, preserve the steps state
+    fn power_off(&mut self) -> Result<(), StepError>;
 }
 
 /// Direction the motor turns in. Just reverses the order of the internal states.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,12 +151,6 @@ impl<P1: OutputPin, P2: OutputPin, P3: OutputPin, P4: OutputPin, D: DelayNs>
     }
 
     fn stop(&mut self) -> Result<(), StepError> {
-        self.state = State::State0;
-        self.apply_state()?;
-        Ok(())
-    }
-
-    fn power_off(&mut self) -> Result<(), StepError> {
         set_state(&mut self.in1, Low)?;
         set_state(&mut self.in2, Low)?;
         set_state(&mut self.in3, Low)?;
@@ -180,10 +174,9 @@ pub trait StepperMotor {
     fn step_for(&mut self, steps: i32, delay: u32) -> Result<(), StepError>;
     /// Set the stepping direction
     fn set_direction(&mut self, dir: Direction);
-    /// Stoping sets all pins low and resets the inner state. Might skip some steps next time step / step_for is called
+    /// Stoping sets all pins low
     fn stop(&mut self) -> Result<(), StepError>;
-    /// Same as stop, but preserve the steps state, so calling step after this should continue as expected
-    fn power_off(&mut self) -> Result<(), StepError>;
+
 }
 
 /// Direction the motor turns in. Just reverses the order of the internal states.


### PR DESCRIPTION
Might be a niche use case, but I'm using an uln2003 to drive a clock. Since I only need to move it once a minute, it makes sense to power the stepper off in-between movements.

The existing stop implementation does power it off, but also resets the half-steps state, so the stepper is not in the right state once you call step again, and it skips some steps. Which is noticeable enough when you are building a clock :)

This introduces a new method to the `StepperMotor` trait which sets all the pins to low, but doesn't update the state on the `ULN2003`. That way, next time a call to `step` happens, it should work, and not miss steps. Tried my best at explaining that in the doc string.

It could be argued that this should be the behavior of `stop`, but it would be a breaking change, so opted for introducing a new method instead. Happy to change the MR to change `stop` directly, if preferred. 

